### PR TITLE
Handle 401 Responses from DGII Endpoints

### DIFF
--- a/src/ecf/__tests__/ECF.test.ts
+++ b/src/ecf/__tests__/ECF.test.ts
@@ -222,4 +222,15 @@ describe('Test Authentication flow', () => {
       expect(message.codigo).toBe(2);
     }
   });
+
+  it('Testing interceptor 401 response', async () => {
+    try {
+      const trackId = testTrackingNo;
+      const ecf = new ECF(certs, ENVIRONMENT.DEV, undefined);
+      await ecf.statusTrackId(trackId);
+    } catch (err) {
+      const error = err as any;
+        expect(error.status).toEqual(401);
+    }
+  });
 });

--- a/src/networking/restClient.ts
+++ b/src/networking/restClient.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { isAxiosError } from 'axios';
 import crypto from 'crypto';
 import https from 'https';
 
@@ -24,6 +24,19 @@ export const restClient = axios.create({
     secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
   }),
 });
+
+restClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (isAxiosError(error) && error.status === 401) {
+      throw {
+        status: 401,
+        message: 'ERROR 401: Unauthorized, please check your credentials',
+      };    
+    }
+    throw error;
+  }
+);
 
 export const setAuthToken = (token: string) => {
   restClient.defaults.headers.common['Authorization'] = `Bearer ${token}`;


### PR DESCRIPTION
This PR addresses an issue where the library was making requests to the DGII endpoints without having first called the authenticate method, or when the token provided during the authenticate method call had expired.

Previously, Axios would return a 401 status code, but the error message was an empty string (''). This made it difficult to understand and handle the error properly.

With this fix, the error now returns as an object describing the error. This makes it easier to understand what went wrong and how to handle the error.

Changes:
- Added a test for 401 responses in `ECF.test.ts`.
- Updated the error handling in the request to return an error object instead of an empty string.

This should improve error handling and debugging when making requests to the DGII endpoints.