### PR TITLE
Fix error restClient error.status was undefined

### DIFF
--- a/src/networking/restClient.ts
+++ b/src/networking/restClient.ts
@@ -28,11 +28,11 @@ export const restClient = axios.create({
 restClient.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (isAxiosError(error) && error.status === 401) {
+    if (isAxiosError(error) && error.response?.status === 401) {
       throw {
         status: 401,
         message: 'ERROR 401: Unauthorized, please check your credentials',
-      };    
+      };
     }
     throw error;
   }


### PR DESCRIPTION
This PR addresses an issue in the restClient.ts file where error.status was undefined or non-existent.

The code has been updated to use error.response?.status instead of error.status.