### PR TITLE
Fix typo in rncEmisor field name

### DIFF
--- a/src/networking/types.ts
+++ b/src/networking/types.ts
@@ -23,7 +23,7 @@ export type Status = 'No encontrado' | 'Aceptado' | 'Rechazado';
 export interface InquiryStatusResponse {
   codigo: StatusCode;
   estado: Status;
-  rncEmiso?: string;
+  rncEmisor?: string;
   ncfElectronico?: string;
   montoTotal?: number;
   totalITBIS?: number;


### PR DESCRIPTION
This pull request fixes a typo in the field name "rncEmisor" in the InquiryStatusResponse interface. The incorrect field name "rncEmiso" has been corrected to "rncEmisor".