### PR TITLE
Remove legacy HTTPS agent configuration and bump version to 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgii-ecf",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Este paquete contiene las herramientas necesarias para autenticar y firmar archivos eletrónicos para realizar la facturación electrónica para aplicaciones nodejs.",
   "private": false,
   "repository": "https://github.com/victors1681/dgii-ecf",

--- a/src/networking/restClient.ts
+++ b/src/networking/restClient.ts
@@ -16,13 +16,13 @@ export enum BaseUrl {
 
 export const restClient = axios.create({
   baseURL: BaseUrl.ECF,
-  httpsAgent: new https.Agent({
-    // node 18x
-    // https://stackoverflow.com/questions/74324019/allow-legacy-renegotiation-for-nodejs/74600467#74600467
-    // rejectUnauthorized: false,
-    // allow legacy server
-    secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
-  }),
+  // httpsAgent: new https.Agent({
+  //   // node 18x
+  //   // https://stackoverflow.com/questions/74324019/allow-legacy-renegotiation-for-nodejs/74600467#74600467
+  //   // rejectUnauthorized: false,
+  //   // allow legacy server
+  //   secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
+  // }), //? this is making the request to fail with the error: "Error: write EPROTO 140735259084352:error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure:../deps/openssl/openssl/ssl/record/rec_layer_s3.c:1407:SSL alert number 40"
 });
 
 restClient.interceptors.response.use(


### PR DESCRIPTION
Eliminate legacy HTTPS agent settings to resolve SSL handshake failures and update the package version.