### PR TITLE
Enforce secure TLS versions and ciphers for compliance

### DIFF
--- a/src/networking/restClient.ts
+++ b/src/networking/restClient.ts
@@ -1,4 +1,6 @@
 import axios, { isAxiosError } from 'axios';
+import https from 'https';
+
 export enum ENVIRONMENT {
   DEV = 'TesteCF',
   CERT = 'CerteCF',
@@ -13,6 +15,20 @@ export enum BaseUrl {
 
 export const restClient = axios.create({
   baseURL: BaseUrl.ECF,
+  httpsAgent: new https.Agent({
+    keepAlive: true,
+    minVersion: 'TLSv1.2',
+    maxVersion: 'TLSv1.3',
+    ciphers: [
+      'ECDHE-ECDSA-AES128-GCM-SHA256',
+      'ECDHE-RSA-AES128-GCM-SHA256',
+      'ECDHE-ECDSA-AES256-GCM-SHA384',
+      'ECDHE-RSA-AES256-GCM-SHA384',
+      'DHE-RSA-AES128-GCM-SHA256',
+      'DHE-RSA-AES256-GCM-SHA384',
+    ].join(':'),
+    honorCipherOrder: true,
+  }),
 });
 
 restClient.interceptors.response.use(


### PR DESCRIPTION
Resolve TLS handshake errors by enforcing the use of TLS 1.2 and 1.3 with secure cipher suites, ensuring compliance with DGII service requirements and enhancing secure communication.