### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-04-17
+
 ### Added
 
 - **Auto-detection of XML root elements**: The `signXml()` method now automatically detects the root element name from the XML document, making the `rootElName` parameter optional. This simplifies the API and reduces potential errors from typos.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgii-ecf",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Este paquete contiene las herramientas necesarias para autenticar y firmar archivos eletrónicos para realizar la facturación electrónica para aplicaciones nodejs.",
   "private": false,
   "repository": {


### PR DESCRIPTION
Bumps version to `1.8.0` so the npm publish workflow can succeed.

The previous publish failed with:
```
403 Forbidden - You cannot publish over the previously published versions: 1.7.1.
```

### Changes
- `package.json`: `1.7.1` → `1.8.0` (minor bump — new feature added in #22)
- `CHANGELOG.md`: moved Unreleased entries under `[1.8.0] - 2026-04-17`

Release contents come from merged #22 (auto-detection of XML root elements + support for arbitrary XML documents).